### PR TITLE
Fix faulty Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ openai = "*"
 pinecone-client = "*"
 unstructured = "*"
 nltk = "*"
-python-magic-bin = "*"
+#python-magic-bin = "*"
 fastapi = "*"
 jinja2 = "*"
 uvicorn = "*"
@@ -24,4 +24,3 @@ tqdm = "*"
 
 [requires]
 python_version = "3.11"
-python_full_version = "3.11.0"


### PR DESCRIPTION
Fix for Pipfile failing due to bad package
ERROR: No matching distribution found for python-magic-bin
