### PR TITLE
Update Udemy course coupon code from FEB-2026 to APRIL-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Tavily](https://img.shields.io/badge/Tavily-🔍-purple.svg)](https://app.tavily.com/home?utm_campaign=eden_marco&utm_medium=socials&utm_source=linkedin)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[![udemy](https://img.shields.io/badge/LangChain%20Udemy%20Course-%2412.99-green)](https://www.udemy.com/course/langchain/?couponCode=FEB-2026)
+[![udemy](https://img.shields.io/badge/LangChain%20Udemy%20Course-%2412.99-green)](https://www.udemy.com/course/langchain/?couponCode=APRIL-2026)
 
 </div>
 


### PR DESCRIPTION
## Summary
Updated the promotional coupon code in the README badge for the LangChain Udemy course to reflect the current promotional period.

## Changes
- Updated the Udemy course badge coupon parameter from `FEB-2026` to `APRIL-2026`
- This ensures the badge directs users to the correct promotional offer

## Details
The change updates the course link to use the April 2026 promotional coupon code instead of the February 2026 code, keeping the promotional materials current and aligned with the active campaign period.

https://claude.ai/code/session_01JHqHyPbwTdg4nXcbZ8d4vX